### PR TITLE
Support thick vs thin provisioning stats.

### DIFF
--- a/openstack_exporter/collectors/cinderbackend.py
+++ b/openstack_exporter/collectors/cinderbackend.py
@@ -13,7 +13,7 @@
 #    under the License.
 
 import logging
-from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.core import GaugeMetricFamily, InfoMetricFamily
 
 from openstack_exporter import BaseCollector
 
@@ -23,6 +23,8 @@ LOG = logging.getLogger('openstack_exporter.exporter')
 class CinderBackendCollector(BaseCollector.BaseCollector):
 
     def describe(self):
+        yield InfoMetricFamily('cinder_provisioning_type',
+                               'Cinder provisioning type')
         yield GaugeMetricFamily('cinder_total_capacity_gib',
                                 'Cinder total capacity in GiB')
         yield GaugeMetricFamily('cinder_free_capacity_gib',
@@ -36,11 +38,29 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
         yield GaugeMetricFamily('cinder_free_until_overcommit_gib',
                                 'Cinder free space until Overcommit reached')
 
+    def _can_overcommit(self, caps, volume_types):
+        can_overcommit = False
+        # Find the volume type associated with the backend
+        vt = volume_types[caps['volume_backend_name']]
+
+        # Only allow overcommit if the volume type that matches
+        # The backend is thin provisioned.
+        if (vt['extra_specs'].get('provisioning:type', 'thin') == 'thin'):
+            can_overcommit = True
+
+        return can_overcommit
+
     def collect(self):
         # logic goes in here
         LOG.info("Collect cinder backend info. {}".format(
             self.config['auth_url']
         ))
+
+        v_types = list(self.client.volume.types())
+        # Ignore volume types that aren't tied to a backend.
+        volume_types = (
+            {vt['extra_specs']['volume_backend_name']:
+             vt for vt in v_types if 'volume_backend_name' in vt['extra_specs']})
 
         pools = self.client.volume.backend_pools()
         for pool in pools:
@@ -51,6 +71,18 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
                 self.region,
                 shard_name,
                 backend))
+
+            # The volume backend can do overcommit if and only if
+            # the backdnd and volume type are set to thin provisioning.
+            can_overcommit = self._can_overcommit(caps, volume_types)
+
+            g = InfoMetricFamily('cinder_provisioning_type',
+                                 'Cinder provisioning type',
+                                 labels=['backend', 'shard'])
+            provisioning_type = ('thin' if can_overcommit else 'thick')
+            g.add_metric([backend, shard_name],
+                         value={'provisioning_type': provisioning_type})
+            yield g
 
             g = GaugeMetricFamily('cinder_total_capacity_gib',
                                   'Cinder total capacity in GiB',
@@ -73,38 +105,43 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
                          value=caps['allocated_capacity_gb'])
             yield g
 
-            g = GaugeMetricFamily('cinder_max_oversubscription_ratio',
-                                  'Cinder max overcommit ratio',
-                                  labels=['backend', 'shard'])
-            g.add_metric([backend, shard_name],
-                         value=caps['max_over_subscription_ratio'])
-            yield g
+            if can_overcommit:
+                g = GaugeMetricFamily('cinder_max_oversubscription_ratio',
+                                      'Cinder max overcommit ratio',
+                                      labels=['backend', 'shard'])
+                g.add_metric([backend, shard_name],
+                             value=caps['max_over_subscription_ratio'])
+                yield g
 
-            if caps['total_capacity_gb']:
-                overcommit_ratio = (caps['allocated_capacity_gb'] /
-                                    caps['total_capacity_gb'])
-            else:
-                overcommit_ratio = 0
-            g = GaugeMetricFamily('cinder_overcommit_ratio',
-                                  'Cinder Overcommit ratio',
-                                  labels=['backend', 'shard'])
-            g.add_metric([backend, shard_name],
-                         value=overcommit_ratio)
-            yield g
+                if caps['total_capacity_gb']:
+                    overcommit_ratio = (caps['allocated_capacity_gb'] /
+                                        caps['total_capacity_gb'])
+                else:
+                    overcommit_ratio = 0
+                g = GaugeMetricFamily('cinder_overcommit_ratio',
+                                      'Cinder Overcommit ratio',
+                                      labels=['backend', 'shard'])
+                g.add_metric([backend, shard_name],
+                             value=overcommit_ratio)
+                yield g
 
-            free_until_overcommit = 0
-            if (caps['total_capacity_gb'] and
-               'max_over_subscription_ratio' in caps):
-                tmp = (caps['total_capacity_gb'] *
-                    float(caps['max_over_subscription_ratio']))
-                free_until_overcommit = tmp - caps['allocated_capacity_gb']
-            g = GaugeMetricFamily('cinder_free_until_overcommit_gib',
-                                  'Cinder free space until Overcommit in GiB',
-                                  labels=['backend', 'shard'])
-            g.add_metric([backend, shard_name],
-                         value=free_until_overcommit)
-            yield g
+                free_until_overcommit = 0
+                if (caps['total_capacity_gb'] and
+                   'max_over_subscription_ratio' in caps):
+                    tmp = (caps['total_capacity_gb'] *
+                        float(caps['max_over_subscription_ratio']))
+                    free_until_overcommit = tmp - caps['allocated_capacity_gb']
+                g = GaugeMetricFamily('cinder_free_until_overcommit_gib',
+                                      'Cinder free space until Overcommit in GiB',
+                                      labels=['backend', 'shard'])
+                g.add_metric([backend, shard_name],
+                             value=free_until_overcommit)
+                yield g
 
+            LOG.debug('({}/{})-provisioning_type = {}'.format(
+                shard_name, caps['volume_backend_name'],
+                provisioning_type
+            ))
             LOG.debug('({}/{})-total_capacity_gb = {}'.format(
                 shard_name, caps['volume_backend_name'],
                 caps['total_capacity_gb']
@@ -117,15 +154,17 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
                 shard_name, caps['volume_backend_name'],
                 caps['allocated_capacity_gb']
             ))
-            LOG.debug('({}/{})-free_until_overcommit = {}'.format(
-                shard_name, caps['volume_backend_name'],
-                free_until_overcommit
-            ))
-            LOG.debug('({}/{})-max_over_subscription_ratio = {}'.format(
-                shard_name, caps['volume_backend_name'],
-                caps['max_over_subscription_ratio']
-            ))
-            LOG.debug('({}/{})-overcommit_ratio = {}'.format(
-                shard_name, caps['volume_backend_name'],
-                overcommit_ratio
-            ))
+
+            if can_overcommit:
+                LOG.debug('({}/{})-free_until_overcommit = {}'.format(
+                    shard_name, caps['volume_backend_name'],
+                    free_until_overcommit
+                ))
+                LOG.debug('({}/{})-max_over_subscription_ratio = {}'.format(
+                    shard_name, caps['volume_backend_name'],
+                    caps['max_over_subscription_ratio']
+                ))
+                LOG.debug('({}/{})-overcommit_ratio = {}'.format(
+                    shard_name, caps['volume_backend_name'],
+                    overcommit_ratio
+                ))


### PR DESCRIPTION
This patch ensures that each backend is reported correctly when
the provisioning type is thin vs thick.  Thick provisioning cannot
do overcommit ratios, since overcommit doesn't exist for thick
provisioned backends.

The new metrics update as follows:
Metrics always provided:
 - total_capacity
 - free_capacity
 - allocated capacity
 - provisioning_type

If the backend is thin, it reports all the overcommit based statistics
as well.
  - max_over_subscription_ratio
  - overcommit_ratio
  - free_until_overcommit

If the backend is thick, then no overcommit statistics will be provided.