### PR TITLE
[Openstack-exporter] fix the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine:3.12
 
 LABEL source_repository="https://github.com/sapcc/openstack-exporter"
 RUN apk --update add python3 openssl ca-certificates bash python3-dev  git py3-pip && \
-    apk --update add --virtual build-dependencies libffi-dev openssl-dev libxml2 libxml2-dev libxslt libxslt-dev build-base
+    apk --update add --virtual build-dependencies libffi-dev openssl-dev libxml2 \
+    libxml2-dev libxslt libxslt-dev build-base rust cargo
 RUN git config --global http.sslVerify false
 RUN git clone https://github.com/sapcc/openstack-exporter.git
 RUN pip3 install --upgrade pip
+RUN pip3 install setuptools_rust
 
 ADD . openstack-exporter/
 RUN cd openstack-exporter && pip3 install .


### PR DESCRIPTION
Docker build was failing due to missing rust, cargo and
setuptools_rust packages needed for python3 crypto library.