### PR TITLE
[Cinder] Add reporting of max volume size

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests
 pyyaml
 master_password
 openstacksdk
+python-cinderclient


### PR DESCRIPTION
This patch adds the python-cinderclient as a requirement so that
the cinderbackend collector can pull the quota information from cinder.
The openstacksdk 0.61.0 release, which is the latest as of this patch,
does not support the quota functions for cinder.

This patch adds a new metric of cinder_per_volume_gigabytes, which is
the max volume size.