### PR TITLE
[Cinder] report on empty backends

### DIFF
--- a/openstack-config-sample.yaml
+++ b/openstack-config-sample.yaml
@@ -14,6 +14,15 @@ collectors:
   cinderbackend:
     collector: openstack_exporter.collectors.cinderbackend.CinderBackendCollector
     enabled: True
+    # The expected backends that support sharding
+    # The exporter will report stats for each sharding backend
+    # If there are no pools currently seen for that backend then the backend is down
+    expected_sharding_backends: vmware, standard_hdd
+    # The expected backends that don't support sharding that we always
+    # want to report.  If there are no pools found then that backend is down.
+    # expected_no_sharding_backends: backendA, backendB
+    # Allow reporting on unexpected backends discovered from stats
+    allow_unexpected_backends: False
   novabackend:
     collector: openstack_exporter.collectors.novaservice.NovaServiceCollector
     enabled: True

--- a/openstack_exporter/BaseCollector.py
+++ b/openstack_exporter/BaseCollector.py
@@ -26,8 +26,9 @@ openstack.enable_logging(debug=False, http_debug=False, stream=sys.stdout)
 
 class BaseCollector(ABC):
 
-    def __init__(self, openstack_config):
+    def __init__(self, openstack_config, collector_config):
         self.config = openstack_config
+        self.collector_config = collector_config
         self.region = self.config['region']
         self.client = self._connect()
 

--- a/openstack_exporter/collectors/cinderbackend.py
+++ b/openstack_exporter/collectors/cinderbackend.py
@@ -16,23 +16,50 @@ import logging
 import math
 from prometheus_client.core import GaugeMetricFamily, InfoMetricFamily
 
+from cachetools import cached, TTLCache
 from cinderclient import client as cinder
 from openstack_exporter import BaseCollector
 
 LOG = logging.getLogger('openstack_exporter.exporter')
 
+DEFAULT_VALID_SHARDING_BACKENDS = ['standard_hdd', 'vmware']
+DEFAULT_VALID_NO_SHARD_BACKENDS = []
+ALLOW_UNEXPECTED_BACKENDS_DEFAULT = False
+
 
 class CinderBackendCollector(BaseCollector.BaseCollector):
-    version = "1.0.2"
+    version = "1.0.3"
 
-    def __init__(self, openstack_config):
-        super().__init__(openstack_config)
+    def __init__(self, openstack_config, collector_config):
+        super().__init__(openstack_config, collector_config)
         # We have to create a cinder client here
         # because the openstacksdk doesn't currently
         # Support the quota functions.
         self.cinder_client = self._cinder_client()
         self.labels = ['backend', 'pool', 'shard']
         LOG.debug(f"Openstack Exporter CinderBackend Version {self.version}")
+        LOG.debug(f"Collector configuration {self.collector_config}")
+        # Make sure there is a default setting for valid_backends
+        cinder_config = self.collector_config['cinderbackend']
+        if 'expected_sharding_backends' not in cinder_config:
+            self.expected_sharding_backends = DEFAULT_VALID_SHARDING_BACKENDS
+        else:
+            backends = cinder_config['expected_sharding_backends']
+            self.expected_sharding_backends = [x.strip() for x in backends.split(',')]
+        if 'expected_no_sharding_backends' not in cinder_config:
+            self.expected_no_sharding_backends = DEFAULT_VALID_NO_SHARD_BACKENDS
+        else:
+            backends = cinder_config['expected_no_sharding_backends']
+            self.expected_no_sharding_backends = [x.strip() for x in backends.split(',')]
+
+        self.allow_unexpected_backends = cinder_config.get(
+            'allow_unexpected_backends', ALLOW_UNEXPECTED_BACKENDS_DEFAULT)
+        LOG.debug("Allowed Expected Sharding Backends "
+                  f"{self.expected_sharding_backends}")
+        LOG.debug("Allowed Expected Non Sharding Backends "
+                  f"{self.expected_no_sharding_backends}")
+        LOG.debug(f"Allow Unexpected Backends? {self.allow_unexpected_backends}")
+        LOG.debug(f"Shards discovered: {self.shards()}")
 
     def _cinder_client(self):
         """openstacksdk doesn't have quota functions yet."""
@@ -63,6 +90,16 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
             os_auth_url,
             **client_args,
         )
+
+    # Cache the shards for 30 minutes since it's painful to fetch
+    @cached(cache=TTLCache(maxsize=50, ttl=1800))
+    def shards(self):
+        shard_names = []
+        LOG.debug("Fetching shard names")
+        for agg in self.client.compute.aggregates():
+            if agg.name.startswith('vc-'):
+                shard_names.append(agg.name)
+        return shard_names
 
     def describe(self):
         yield GaugeMetricFamily('cinder_per_volume_gigabytes',
@@ -180,15 +217,17 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
     def _parse_pool_data(self, pool, volume_type):
         """Construct the data from the pool information from the scheduler."""
         caps = pool['capabilities']
+        shard_name = caps.get('vcenter-shard')
+
         data = {"backend": caps["volume_backend_name"],
                 "pool": pool['name'].split('#')[1],
-                "shard": caps["vcenter-shard"]}
+                "shard": shard_name}
         can_overcommit = False
 
         # Only allow overcommit if the volume type that matches
         # The backend is thin provisioned.
         # A missing key of provisioning:type means thin provisioning.
-        if volume_type['extra_specs'].get('provisioning:type') != 'thick':
+        if volume_type and volume_type['extra_specs'].get('provisioning:type') != 'thick':
             can_overcommit = True
 
         total_capacity_gb = caps.get('total_capacity_gb', 0)
@@ -252,112 +291,88 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
         gauge.add_metric([backend, pool, shard], value=value)
         return self._debug_gauge(gauge, name, value, shard, backend, pool)
 
-    def collect(self):
-        # logic goes in here
-        LOG.info("Collect cinder backend info. {}".format(
-            self.config['auth_url']
-        ))
-        project_id = self.client.volume.get_project_id()
-        quota_obj = self.cinder_client.quotas.defaults(project_id)
+    def _report_stats(self, shard_name, backend, data, caps, quota_obj):
+        pool_name = data['pool']
+        yield self.add_gauge_metric_gauge(
+            'cinder_per_volume_gigabytes',
+            'Cinder max volume size in GiB',
+            quota_obj.per_volume_gigabytes,
+            shard_name, backend, pool_name
+        )
+        yield self.add_info_metric_gauge(
+            'cinder_backend_state',
+            'State of cinder backend up/down',
+            {'backend_state': caps.get('backend_state', 'down')},
+            shard_name, backend, pool_name
+        )
+        yield self.add_info_metric_gauge(
+            'cinder_pool_state',
+            'State of cinder pool up/down',
+            {'pool_state': caps.get('pool_state', 'down')},
+            shard_name, backend, pool_name
+        )
 
-        v_types = list(self.client.volume.types())
-        # Ignore volume types that aren't tied to a backend.
-        volume_types = (
-            {vt['extra_specs']['volume_backend_name']:
-             vt for vt in v_types if 'volume_backend_name' in vt['extra_specs']})
+        # The volume backend can do overcommit if and only if
+        # the backdnd and volume type are set to thin provisioning.
+        can_overcommit = data["can_overcommit"]
 
-        pools = self.client.volume.backend_pools()
-        for pool in pools:
-            caps = pool['capabilities']
-            backend = caps['volume_backend_name']
-            shard_name = caps['vcenter-shard']
-            volume_type = volume_types[backend]
-            data = self._parse_pool_data(pool, volume_type)
-            pool_name = data['pool']
-            LOG.debug(f"Got stats for {self.region} {shard_name}/{backend}/{pool_name}")
+        provisioning_type = ('thin' if can_overcommit else 'thick')
+        yield self.add_info_metric_gauge(
+            'cinder_provisioning_type',
+            'Cinder provisioning type',
+            {'provisioning_type': provisioning_type},
+            shard_name, backend, pool_name
+        )
 
+        yield self.add_gauge_metric_gauge(
+            'cinder_total_capacity_gib',
+            'Cinder total capacity in GiB',
+            data['total_capacity_gb'],
+            shard_name, backend, pool_name
+        )
+
+        yield self.add_gauge_metric_gauge(
+            'cinder_available_capacity_gib',
+            'Cinder available capacity in GiB',
+            data['available_capacity_gb'],
+            shard_name, backend, pool_name
+        )
+
+        yield self.add_gauge_metric_gauge(
+            'cinder_free_capacity_gib',
+            'Cinder reported free capacity in GiB',
+            data['free_capacity_gb'],
+            shard_name, backend, pool_name
+        )
+
+        yield self.add_gauge_metric_gauge(
+            'cinder_virtual_free_capacity_gib',
+            'Cinder virtual free capacity in GiB',
+            data['virtual_free_capacity_gb'],
+            shard_name, backend, pool_name
+        )
+
+        yield self.add_gauge_metric_gauge(
+            'cinder_allocated_capacity_gib',
+            'Cinder allocated capacity in GiB',
+            data['allocated_capacity_gb'],
+            shard_name, backend, pool_name
+        )
+
+        if can_overcommit:
             yield self.add_gauge_metric_gauge(
-                'cinder_per_volume_gigabytes',
-                'Cinder max volume size in GiB',
-                quota_obj.per_volume_gigabytes,
-                shard_name, backend, pool_name
-            )
-
-            yield self.add_info_metric_gauge(
-                'cinder_backend_state',
-                'State of cinder backend up/down',
-                {'backend_state': caps.get('backend_state', 'down')},
-                shard_name, backend, pool_name
-            )
-            yield self.add_info_metric_gauge(
-                'cinder_pool_state',
-                'State of cinder pool up/down',
-                {'pool_state': caps.get('pool_state', 'down')},
-                shard_name, backend, pool_name
-            )
-
-            # The volume backend can do overcommit if and only if
-            # the backdnd and volume type are set to thin provisioning.
-            can_overcommit = data["can_overcommit"]
-
-            provisioning_type = ('thin' if can_overcommit else 'thick')
-            yield self.add_info_metric_gauge(
-                'cinder_provisioning_type',
-                'Cinder provisioning type',
-                {'provisioning_type': provisioning_type},
-                shard_name, backend, pool_name
-            )
-
-            yield self.add_gauge_metric_gauge(
-                'cinder_total_capacity_gib',
-                'Cinder total capacity in GiB',
-                data['total_capacity_gb'],
-                shard_name, backend, pool_name
-            )
-
-            yield self.add_gauge_metric_gauge(
-                'cinder_available_capacity_gib',
-                'Cinder available capacity in GiB',
-                data['available_capacity_gb'],
-                shard_name, backend, pool_name
-            )
-
-            yield self.add_gauge_metric_gauge(
-                'cinder_free_capacity_gib',
-                'Cinder reported free capacity in GiB',
-                data['free_capacity_gb'],
-                shard_name, backend, pool_name
-            )
-
-            yield self.add_gauge_metric_gauge(
-                'cinder_virtual_free_capacity_gib',
-                'Cinder virtual free capacity in GiB',
-                data['virtual_free_capacity_gb'],
+                'cinder_max_oversubscription_ratio',
+                'Cinder max overcommit ratio',
+                data['max_over_subscription_ratio'],
                 shard_name, backend, pool_name
             )
 
             yield self.add_gauge_metric_gauge(
-                'cinder_allocated_capacity_gib',
-                'Cinder allocated capacity in GiB',
-                data['allocated_capacity_gb'],
+                'cinder_overcommit_ratio',
+                'Cinder Overcommit ratio',
+                data['overcommit_ratio'],
                 shard_name, backend, pool_name
             )
-
-            if can_overcommit:
-                yield self.add_gauge_metric_gauge(
-                    'cinder_max_oversubscription_ratio',
-                    'Cinder max overcommit ratio',
-                    data['max_over_subscription_ratio'],
-                    shard_name, backend, pool_name
-                )
-
-                yield self.add_gauge_metric_gauge(
-                    'cinder_overcommit_ratio',
-                    'Cinder Overcommit ratio',
-                    data['overcommit_ratio'],
-                    shard_name, backend, pool_name
-                )
-
             yield self.add_gauge_metric_gauge(
                 'cinder_reserved_percentage',
                 'Cinder Reserved Space Percentage',
@@ -380,3 +395,94 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
                 {'netapp_fqdn': netapp_fqdn},
                 shard_name, backend, pool_name
             )
+
+    def collect(self):
+        """This is the collector for cinder backends.
+
+        This calls the cinder scheduler api to get all the pool stats
+        that the scheduler sees.  If a backend is down and the stats aren't
+        being collected by the driver for that backend, then the scheduler will
+        not have any stats.  The collector has an expected list of backends
+        that it wants to see coming from the scheduler API.  The execpted
+        backends are configurable in the config file.  See the sample config
+
+        For each expected backend the collector will report stats.
+        If the backend isn't seen in the stats from the scheduler API,
+        then the collector will report 0 capacity.
+
+        """
+        LOG.info("Collect cinder backend info. {}".format(
+            self.config['auth_url']
+        ))
+        project_id = self.client.volume.get_project_id()
+        quota_obj = self.cinder_client.quotas.defaults(project_id)
+
+        v_types = list(self.client.volume.types())
+        # Ignore volume types that aren't tied to a backend.
+        volume_types = (
+            {vt['extra_specs']['volume_backend_name']:
+             vt for vt in v_types if 'volume_backend_name' in vt['extra_specs']})
+
+        pools = self.client.volume.backend_pools()
+
+        # Keep a count of each backend in each shard for each pool.
+        # If we don't see any pools in a shard/backend then it's down and
+        # we will report that shard/backend as reporting 0 capacity.
+        default_shard_backends = dict([(key, 0) for key in self.expected_sharding_backends])
+        default_no_shard_backends = dict([(key, 0) for key in self.expected_no_sharding_backends])
+        # 'None' key means the shard name 'None' for backends
+        # That aren't affiliated with sharding.
+        no_shard = 'None'
+        seen_backends = {no_shard: default_no_shard_backends.copy()}
+        # populate the seen_backends with expected shards
+        for shard_name in self.shards():
+            seen_backends[shard_name] = default_shard_backends.copy()
+        LOG.debug(f"Expecting backends {self.expected_sharding_backends}")
+        LOG.debug(f"Initial stats {seen_backends}")
+        for pool in pools:
+            caps = pool['capabilities']
+            backend = caps['volume_backend_name']
+            shard_name = no_shard
+            if 'vcenter-shard' in caps:
+                shard_name = caps['vcenter-shard']
+            volume_type = None
+            if backend in volume_types:
+                volume_type = volume_types[backend]
+            else:
+                LOG.debug(f"Backend {backend} has no associated volume type")
+
+            # initialize the accounting for the shard
+            if shard_name not in seen_backends:
+                seen_backends[shard_name] = default_shard_backends.copy()
+
+            data = self._parse_pool_data(pool, volume_type)
+            pool_name = data['pool']
+
+            if shard_name != no_shard:
+                LOG.debug(f"Got stats for {self.region} "
+                          f"{shard_name}/{backend}/{pool_name}")
+            else:
+                LOG.debug(f"Got stats for {self.region} {backend}/{pool_name}")
+
+            yield from self._report_stats(
+                shard_name, backend, data, caps, quota_obj)
+            if backend in seen_backends[shard_name]:
+                seen_backends[shard_name][backend] += 1
+            elif self.allow_unexpected_backends:
+                LOG.debug(f"Adding unexpected backend {backend} "
+                          f"to shard {shard_name}")
+                seen_backends[shard_name][backend] = 1
+            else:
+                LOG.warning(f"Backend {backend} is not in expected "
+                            f"backends {self.expected_sharding_backends}")
+
+        LOG.debug(f"seen backends {seen_backends}")
+        for shard in seen_backends:
+            for backend in seen_backends[shard]:
+                if seen_backends[shard][backend] == 0:
+                    LOG.debug(f"{shard} / {backend} is down")
+                    yield self.add_gauge_metric_gauge(
+                        'cinder_free_capacity_gib',
+                        'Cinder reported free capacity in GiB',
+                        0, shard, backend, "None"
+                    )

--- a/openstack_exporter/exporter.py
+++ b/openstack_exporter/exporter.py
@@ -58,7 +58,8 @@ def load_and_register_collectors(collector_config, openstack_config):
         cfg = collector_config[collector]
         if cfg['enabled']:
             LOG.info("Loading collector '{}'".format(cfg['collector']))
-            cls = factory(cfg['collector'], openstack_config=openstack_config)
+            cls = factory(cfg['collector'], openstack_config=openstack_config,
+                          collector_config=collector_config)
             REGISTRY.register(cls)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyyaml
 master_password
 openstacksdk
 python-cinderclient
+cachetools


### PR DESCRIPTION
This patch adds:
1) The ability to add custom config items for each collector.
   See the example config file for cinder collector config entries.

2) Allow cinder to have a list of configurable expected backends to look
   for in the scheduler stats API call.  If there is a backend that is
   expected to have stats, but isn't seen then the backend is down and
   is reported as having 0 capacity.

3) The cinder collector now handles backends that don't support sharding
   as needed by the kvm testing in qa-de-1.