### PR TITLE
limit cryptography version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ requests
 pyyaml
 master_password
 openstacksdk
+cryptography<43.0.0
 python-cinderclient
 python-manilaclient
 cachetools


### PR DESCRIPTION
ci building fails when installing package cryptography 43.0.1
