### PR TITLE
[Cinder] report aggregated stats

### DIFF
--- a/openstack_exporter/collectors/cinderbackend.py
+++ b/openstack_exporter/collectors/cinderbackend.py
@@ -20,9 +20,11 @@ from cachetools import cached, TTLCache
 from cinderclient import client as cinder
 from openstack_exporter import BaseCollector
 
+from openstack_exporter.utils import cinder as cinder_utils
+
 LOG = logging.getLogger('openstack_exporter.exporter')
 
-DEFAULT_VALID_SHARDING_BACKENDS = ['standard_hdd', 'vmware']
+DEFAULT_VALID_SHARDING_BACKENDS = ['standard_hdd', 'vmware', 'vmware_fcd']
 DEFAULT_VALID_NO_SHARD_BACKENDS = []
 ALLOW_UNEXPECTED_BACKENDS_DEFAULT = False
 
@@ -125,156 +127,6 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
         yield GaugeMetricFamily('cinder_percent_free',
                                 'Cinder Percentage of available space is free.')
 
-    def calculate_capacity_factors(self,
-                                   total_capacity: float,
-                                   free_capacity: float,
-                                   provisioned_capacity: float,
-                                   thin_provisioning_support: bool,
-                                   max_over_subscription_ratio: float,
-                                   reserved_percentage: float,
-                                   thin: bool) -> dict:
-        """Create the various capacity factors of the a particular backend.
-
-        Based off of definition of terms
-        cinder-specs/specs/queens/provisioning-improvements.html
-
-        total_capacity - The reported total capacity in the backend.
-        free_capacity - The free space/capacity as reported by the backend.
-        reserved_capacity - The amount of space reserved from the total_capacity
-        as reported by the backend.
-        total_reserved_available_capacity - The total capacity minus reserved
-        capacity
-
-        max_over_subscription_ratio - as reported by the backend
-        total_available_capacity - The total capacity available to cinder
-        calculated
-        thick: total_reserved_available_capacity
-        OR
-        thin: total_reserved_available_capacity and max_over_subscription_ratio
-
-        provisioned_capacity - as reported by backend or volume manager
-        (allocated_capacity_gb)
-
-        calculated_free_capacity - total_available_capacity - provisioned_capacity
-        virtual_free_capacity - The calculated free capacity available to cinder
-        to allocate new storage.
-        For thin: calculated_free_capacity
-        For thick: the reported free_capacity can be less than the calculated
-        Capacity, so we use free_capacity - reserved_capacity.
-
-        free_percent - the percentage of the virtual_free and
-        total_available_capacity is left over
-        provisioned_ratio - The ratio of provisioned storage to
-        total_available_capacity
-        """
-
-        total = float(total_capacity)
-        reserved = float(reserved_percentage) / 100
-        reserved_capacity = math.floor(total * reserved)
-        total_reserved_available = total - reserved_capacity
-
-        if thin and thin_provisioning_support:
-            total_available_capacity = (
-                total_reserved_available * max_over_subscription_ratio
-            )
-            calculated_free = total_available_capacity - provisioned_capacity
-            virtual_free = calculated_free
-            provisioned_type = 'thin'
-        else:
-            # Calculate how much free space is left after taking into
-            # account the reserved space.
-            total_available_capacity = total_reserved_available
-            calculated_free = total_available_capacity - provisioned_capacity
-            virtual_free = calculated_free
-            if free_capacity < calculated_free:
-                virtual_free = free_capacity
-            provisioned_type = 'thick'
-
-        if total_available_capacity:
-            provisioned_ratio = provisioned_capacity / total_available_capacity
-            free_percent = (virtual_free / total_available_capacity) * 100
-        else:
-            provisioned_ratio = 0
-            free_percent = 0
-
-        return {
-            "total_capacity": total,
-            "free_capacity": free_capacity,
-            "reserved_capacity": reserved_capacity,
-            "total_reserved_available_capacity": int(total_reserved_available),
-            "max_over_subscription_ratio": (
-                max_over_subscription_ratio if provisioned_type == 'thin' else None
-            ),
-            "total_available_capacity": int(total_available_capacity),
-            "provisioned_capacity": provisioned_capacity,
-            "calculated_free_capacity": int(calculated_free),
-            "virtual_free_capacity": int(virtual_free),
-            "free_percent": free_percent,
-            "provisioned_ratio": provisioned_ratio,
-            "provisioned_type": provisioned_type
-        }
-
-    def _parse_pool_data(self, pool, volume_type):
-        """Construct the data from the pool information from the scheduler."""
-        caps = pool['capabilities']
-        shard_name = caps.get('vcenter-shard')
-
-        data = {"backend": caps["volume_backend_name"],
-                "pool": pool['name'].split('#')[1],
-                "shard": shard_name}
-        can_overcommit = False
-
-        # Only allow overcommit if the volume type that matches
-        # The backend is thin provisioned.
-        # A missing key of provisioning:type means thin provisioning.
-        if volume_type and volume_type['extra_specs'].get('provisioning:type') != 'thick':
-            can_overcommit = True
-
-        total_capacity_gb = caps.get('total_capacity_gb', 0)
-        allocated_capacity_gb = caps.get('allocated_capacity_gb', 0)
-        reserved_percentage = caps.get('reserved_percentage', 0)
-        max_over_subscription_ratio = float(
-            caps.get('max_over_subscription_ratio', 1)
-        )
-        free_capacity_gb = caps.get('free_capacity_gb', 0)
-
-        capacity_factors = self.calculate_capacity_factors(
-            total_capacity_gb,
-            free_capacity_gb,
-            allocated_capacity_gb,
-            caps.get('thin_provisioning_support', False),
-            max_over_subscription_ratio,
-            reserved_percentage,
-            can_overcommit,
-        )
-        available_capacity_gb = capacity_factors["total_available_capacity"]
-        virtual_free_gb = capacity_factors["virtual_free_capacity"]
-        percent_left = capacity_factors["free_percent"]
-        overcommit_ratio = capacity_factors["provisioned_ratio"]
-
-        data["can_overcommit"] = can_overcommit
-        data['total_capacity_gb'] = total_capacity_gb
-        data['max_over_subscription_ratio'] = max_over_subscription_ratio
-        data['provisioned_capacity_gb'] = caps.get('provisioned_capacity_gb', 0)
-        data['overcommit_ratio'] = overcommit_ratio
-
-        data['available_capacity_gb'] = available_capacity_gb
-        data['allocated_capacity_gb'] = allocated_capacity_gb
-        # What the backend is reporting
-        data['free_capacity_gb'] = free_capacity_gb
-        # What cinder can use
-        data['virtual_free_capacity_gb'] = virtual_free_gb
-        data['percent_left'] = percent_left
-        data['reserved_percentage'] = reserved_percentage
-
-        if can_overcommit:
-            data['provisioning_type'] = 'thin'
-        else:
-            data['provisioning_type'] = 'thick'
-
-        data['driver_version'] = caps['driver_version']
-        return data
-
     def _debug_gauge(self, gauge, name, value, shard, backend, pool):
         LOG.debug(f"({shard}/{backend}/{pool})-{name} = {value}")
         return gauge
@@ -293,6 +145,9 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
 
     def _report_stats(self, shard_name, backend, data, caps, quota_obj):
         pool_name = data['pool']
+        LOG.debug(f"Reporting stats for {shard_name}/{backend}/{pool_name}")
+        LOG.debug(f"Data {data}")
+        LOG.debug(f"Capabilities {caps}")
         yield self.add_gauge_metric_gauge(
             'cinder_per_volume_gigabytes',
             'Cinder max volume size in GiB',
@@ -309,6 +164,17 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
             'cinder_pool_state',
             'State of cinder pool up/down',
             {'pool_state': caps.get('pool_state', 'down')},
+            shard_name, backend, pool_name
+        )
+        down_reason = caps.get('pool_down_reason', 'unknown')
+        if caps.get('backend_state', 'down') == 'down':
+            down_reason = 'backend_down'
+        elif 'Datastore marked as draining' in down_reason:
+            down_reason = 'draining'
+        yield self.add_info_metric_gauge(
+            'cinder_pool_down_reason',
+            'Reason for pool state being down',
+            {'pool_down_reason': down_reason},
             shard_name, backend, pool_name
         )
 
@@ -359,6 +225,15 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
             shard_name, backend, pool_name
         )
 
+        aggregate_id = data.get("aggregate_id")
+        if aggregate_id:
+            yield self.add_info_metric_gauge(
+                'cinder_aggregate_id',
+                'Cinder aggregate id',
+                {'aggregate_id': aggregate_id},
+                shard_name, backend, pool_name
+            )
+
         if can_overcommit:
             yield self.add_gauge_metric_gauge(
                 'cinder_max_oversubscription_ratio',
@@ -396,6 +271,61 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
                 shard_name, backend, pool_name
             )
 
+    def _report_aggregated_stats(self, backend):
+        pool_name = backend['name']
+        LOG.debug(f"Reporting stats for {backend}/{pool_name}")
+        LOG.debug(f"Aggregate Data {backend}")
+
+        yield self.add_info_metric_gauge(
+            'cinder_aggregate_id',
+            'Cinder aggregate id',
+            {'aggregate_id': backend['aggregate_id']},
+            'aggregate', 'aggregate', pool_name
+        )
+
+        yield self.add_gauge_metric_gauge(
+            'cinder_total_capacity_gib',
+            'Cinder total capacity in GiB',
+            backend['total_capacity_gb'],
+            'aggregate', 'aggregate', pool_name
+        )
+
+        yield self.add_gauge_metric_gauge(
+            'cinder_free_capacity_gib',
+            'Cinder reported free capacity in GiB',
+            backend['free_capacity_gb'],
+            'aggregate', 'aggregate', pool_name
+        )
+
+        yield self.add_gauge_metric_gauge(
+            'cinder_allocated_capacity_gib',
+            'Cinder allocated capacity in GiB',
+            backend['allocated_capacity_gb'],
+            'aggregate', 'aggregate', pool_name
+        )
+
+        yield self.add_gauge_metric_gauge(
+            'cinder_max_oversubscription_ratio',
+            'Cinder max overcommit ratio',
+            backend['max_over_subscription_ratio'],
+            'aggregate', 'aggregate', pool_name
+        )
+
+        yield self.add_gauge_metric_gauge(
+            'cinder_free_percent',
+            'Cinder Percentage of available space is free.',
+            backend['free_percent'],
+            'aggregate', 'aggregate', pool_name
+        )
+
+        yield self.add_gauge_metric_gauge(
+            'cinder_virtual_free_capacity_gib',
+            'Cinder virtual free capacity in GiB',
+            backend['virtual_free_capacity_gb'],
+            'aggregate', 'aggregate', pool_name
+        )
+
+
     def collect(self):
         """This is the collector for cinder backends.
 
@@ -417,13 +347,15 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
         project_id = self.client.volume.get_project_id()
         quota_obj = self.cinder_client.quotas.defaults(project_id)
 
-        v_types = list(self.client.volume.types())
-        # Ignore volume types that aren't tied to a backend.
-        volume_types = (
-            {vt['extra_specs']['volume_backend_name']:
-             vt for vt in v_types if 'volume_backend_name' in vt['extra_specs']})
-
-        pools = self.client.volume.backend_pools()
+        volume_types = cinder_utils.get_volume_types(self.client)
+        # Now filter the pools through the volumes types to get the
+        # pools associated with a volume type.
+        pools = cinder_utils.filter_pools(
+            self.client,
+            cinder_utils.get_cinder_pools(self.client)
+        )
+        # build the aggregated pools list so we can report them as well.
+        aggregated_pools = cinder_utils.aggregate_pools(pools)
 
         # Keep a count of each backend in each shard for each pool.
         # If we don't see any pools in a shard/backend then it's down and
@@ -439,42 +371,44 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
             seen_backends[shard_name] = default_shard_backends.copy()
         LOG.debug(f"Expecting backends {self.expected_sharding_backends}")
         LOG.debug(f"Initial stats {seen_backends}")
-        for pool in pools:
-            caps = pool['capabilities']
-            backend = caps['volume_backend_name']
-            shard_name = no_shard
-            if 'vcenter-shard' in caps:
-                shard_name = caps['vcenter-shard']
-            volume_type = None
-            if backend in volume_types:
-                volume_type = volume_types[backend]
-            else:
-                LOG.debug(f"Backend {backend} has no associated volume type")
+        type_by_name = cinder_utils.get_volume_types_by_name(self.client)
+        for volume_type_name in pools:
+            for pool in pools[volume_type_name]:
+                caps = pool['capabilities']
+                backend = caps['volume_backend_name']
+                shard_name = no_shard
+                if 'vcenter-shard' in caps:
+                    shard_name = caps['vcenter-shard']
+                volume_type = None
+                if backend in volume_types:
+                    volume_type = volume_types[backend]
+                else:
+                    LOG.debug(f"Backend {backend} has no associated volume type")
 
-            # initialize the accounting for the shard
-            if shard_name not in seen_backends:
-                seen_backends[shard_name] = default_shard_backends.copy()
+                # initialize the accounting for the shard
+                if shard_name not in seen_backends:
+                    seen_backends[shard_name] = default_shard_backends.copy()
 
-            data = self._parse_pool_data(pool, volume_type)
-            pool_name = data['pool']
+                data = cinder_utils.parse_pool_data(pool, volume_type)
+                pool_name = data['pool']
 
-            if shard_name != no_shard:
-                LOG.debug(f"Got stats for {self.region} "
-                          f"{shard_name}/{backend}/{pool_name}")
-            else:
-                LOG.debug(f"Got stats for {self.region} {backend}/{pool_name}")
+                if shard_name != no_shard:
+                    LOG.debug(f"Got stats for {self.region} "
+                            f"{shard_name}/{backend}/{pool_name}")
+                else:
+                    LOG.debug(f"Got stats for {self.region} {backend}/{pool_name}")
 
-            yield from self._report_stats(
-                shard_name, backend, data, caps, quota_obj)
-            if backend in seen_backends[shard_name]:
-                seen_backends[shard_name][backend] += 1
-            elif self.allow_unexpected_backends:
-                LOG.debug(f"Adding unexpected backend {backend} "
-                          f"to shard {shard_name}")
-                seen_backends[shard_name][backend] = 1
-            else:
-                LOG.warning(f"Backend {backend} is not in expected "
-                            f"backends {self.expected_sharding_backends}")
+                yield from self._report_stats(
+                    shard_name, backend, data, caps, quota_obj)
+                if backend in seen_backends[shard_name]:
+                    seen_backends[shard_name][backend] += 1
+                elif self.allow_unexpected_backends:
+                    LOG.debug(f"Adding unexpected backend {backend} "
+                            f"to shard {shard_name}")
+                    seen_backends[shard_name][backend] = 1
+                else:
+                    LOG.warning(f"Backend {backend} is not in expected "
+                                f"backends {self.expected_sharding_backends}")
 
         LOG.debug(f"seen backends {seen_backends}")
         for shard in seen_backends:
@@ -486,3 +420,8 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
                         'Cinder reported free capacity in GiB',
                         0, shard, backend, "None"
                     )
+
+        for pool_name in aggregated_pools:
+            yield from self._report_aggregated_stats(
+                aggregated_pools[pool_name]
+            )

--- a/openstack_exporter/utils/cinder.py
+++ b/openstack_exporter/utils/cinder.py
@@ -1,0 +1,359 @@
+
+import logging
+import math
+
+from cachetools import cached, TTLCache
+
+from openstack_exporter.utils import filters
+from openstack_exporter.utils.filters import capabilities
+
+
+LOG = logging.getLogger('openstack_exporter.exporter')
+SAP_HIDDEN_BACKEND_KEY = '__cinder_internal_backend'
+
+
+def extract_host(host, level='backend', default_pool_name=False):
+    """Extract Host, Backend or Pool information from host string.
+
+    :param host: String for host, which could include host@backend#pool info
+    :param level: Indicate which level of information should be extracted
+                  from host string. Level can be 'host', 'backend' or 'pool',
+                  default value is 'backend'
+    :param default_pool_name: this flag specify what to do if level == 'pool'
+                              and there is no 'pool' info encoded in host
+                              string.  default_pool_name=True will return
+                              DEFAULT_POOL_NAME, otherwise we return None.
+                              Default value of this parameter is False.
+    :return: expected information, string or None
+    :raises: exception.InvalidVolume
+
+    For example:
+        host = 'HostA@BackendB#PoolC'
+        ret = extract_host(host, 'host')
+        # ret is 'HostA'
+        ret = extract_host(host, 'backend')
+        # ret is 'HostA@BackendB'
+        ret = extract_host(host, 'pool')
+        # ret is 'PoolC'
+
+        host = 'HostX@BackendY'
+        ret = extract_host(host, 'pool')
+        # ret is None
+        ret = extract_host(host, 'pool', True)
+        # ret is '_pool0'
+    """
+    DEFAULT_POOL_NAME = '_pool0'
+
+    if host is None:
+        raise Exception("Must specify a host")
+
+    if level == 'host':
+        # make sure pool is not included
+        hst = host.split('#')[0]
+        return hst.split('@')[0]
+    elif level == 'backend':
+        return host.split('#')[0]
+    elif level == 'pool':
+        lst = host.split('#')
+        if len(lst) == 2:
+            return lst[1]
+        elif default_pool_name is True:
+            return DEFAULT_POOL_NAME
+        else:
+            return None
+
+
+def calculate_capacity_factors(total_capacity: float,
+                               free_capacity: float,
+                               provisioned_capacity: float,
+                               thin_provisioning_support: bool,
+                               max_over_subscription_ratio: float,
+                               reserved_percentage: float,
+                               thin: bool) -> dict:
+    """Create the various capacity factors of the a particular backend.
+
+    Based off of definition of terms
+    cinder-specs/specs/queens/provisioning-improvements.html
+
+    total_capacity - The reported total capacity in the backend.
+    free_capacity - The free space/capacity as reported by the backend.
+    reserved_capacity - The amount of space reserved from the total_capacity
+    as reported by the backend.
+    total_reserved_available_capacity - The total capacity minus reserved
+    capacity
+
+    max_over_subscription_ratio - as reported by the backend
+    total_available_capacity - The total capacity available to cinder
+    calculated
+    thick: total_reserved_available_capacity
+    OR
+    thin: total_reserved_available_capacity and max_over_subscription_ratio
+
+    provisioned_capacity - as reported by backend or volume manager
+    (allocated_capacity_gb)
+
+    calculated_free_capacity - total_available_capacity - provisioned_capacity
+    virtual_free_capacity - The calculated free capacity available to cinder
+    to allocate new storage.
+    For thin: calculated_free_capacity
+    For thick: the reported free_capacity can be less than the calculated
+    Capacity, so we use free_capacity - reserved_capacity.
+
+    free_percent - the percentage of the total_available_capacity is left over
+    provisioned_ratio - The ratio of provisioned storage to
+    total_available_capacity
+    """
+
+    total = float(total_capacity)
+    reserved = float(reserved_percentage) / 100
+    reserved_capacity = math.floor(total * reserved)
+    total_reserved_available = total - reserved_capacity
+
+    if thin and thin_provisioning_support:
+        total_available_capacity = (
+                total_reserved_available * max_over_subscription_ratio
+        )
+        calculated_free = total_available_capacity - provisioned_capacity
+        virtual_free = calculated_free
+        provisioned_type = 'thin'
+    else:
+        # Calculate how much free space is left after taking into
+        # account the reserved space.
+        total_available_capacity = total_reserved_available
+        calculated_free = total_available_capacity - provisioned_capacity
+        virtual_free = calculated_free
+        if free_capacity < calculated_free:
+            virtual_free = free_capacity
+        max_over_subscription_ratio = None
+        provisioned_type = 'thick'
+
+    if total_available_capacity:
+        provisioned_ratio = provisioned_capacity / total_available_capacity
+        free_percent = (virtual_free / total_available_capacity) * 100
+    else:
+        provisioned_ratio = 0
+        free_percent = 0
+
+    return {
+        "total_capacity": total,
+        "free_capacity": free_capacity,
+        "reserved_capacity": reserved_capacity,
+        "total_reserved_available_capacity": int(total_reserved_available),
+        "max_over_subscription_ratio": (
+                max_over_subscription_ratio if provisioned_type == 'thin' else None
+        ),
+        "total_available_capacity": int(total_available_capacity),
+        "provisioned_capacity": provisioned_capacity,
+        "calculated_free_capacity": int(calculated_free),
+        "virtual_free_capacity": int(virtual_free),
+        "free_percent": free_percent,
+        "provisioned_ratio": provisioned_ratio,
+        "provisioned_type": provisioned_type
+    }
+
+
+def parse_pool_data(pool, volume_type):
+    """Construct the data from the pool information from the scheduler."""
+    caps = pool['capabilities']
+    shard_name = caps.get('vcenter-shard')
+
+    data = {"backend": caps["volume_backend_name"],
+            "pool": pool['name'].split('#')[1],
+            "shard": shard_name}
+    can_overcommit = False
+
+    # Only allow overcommit if the volume type that matches
+    # The backend is thin provisioned.
+    # A missing key of provisioning:type means thin provisioning.
+    if volume_type and volume_type['extra_specs'].get('provisioning:type') != 'thick':
+        can_overcommit = True
+    elif "thin_provisioning_support" in caps:
+        can_overcommit = caps['thin_provisioning_support']
+
+    total_capacity_gb = caps.get('total_capacity_gb', 0)
+    allocated_capacity_gb = caps.get('allocated_capacity_gb', 0)
+    reserved_percentage = caps.get('reserved_percentage', 0)
+    max_over_subscription_ratio = float(
+        caps.get('max_over_subscription_ratio', 1)
+    )
+    free_capacity_gb = caps.get('free_capacity_gb', 0)
+
+    capacity_factors = calculate_capacity_factors(
+        total_capacity_gb,
+        free_capacity_gb,
+        allocated_capacity_gb,
+        caps.get('thin_provisioning_support', False),
+        max_over_subscription_ratio,
+        reserved_percentage,
+        can_overcommit,
+    )
+    available_capacity_gb = capacity_factors["total_available_capacity"]
+    virtual_free_gb = capacity_factors["virtual_free_capacity"]
+    percent_left = capacity_factors["free_percent"]
+    overcommit_ratio = capacity_factors["provisioned_ratio"]
+
+    data["can_overcommit"] = can_overcommit
+    data['total_capacity_gb'] = total_capacity_gb
+    data['max_over_subscription_ratio'] = max_over_subscription_ratio
+    data['provisioned_capacity_gb'] = caps.get('provisioned_capacity_gb', 0)
+    data['overcommit_ratio'] = overcommit_ratio
+
+    data['available_capacity_gb'] = available_capacity_gb
+    data['allocated_capacity_gb'] = allocated_capacity_gb
+    # What the backend is reporting
+    data['free_capacity_gb'] = free_capacity_gb
+    # What cinder can use
+    data['virtual_free_capacity_gb'] = virtual_free_gb
+    data['percent_left'] = percent_left
+    data['reserved_percentage'] = reserved_percentage
+
+    if can_overcommit:
+        data['provisioning_type'] = 'thin'
+    else:
+        data['provisioning_type'] = 'thick'
+
+    if 'aggregate_id' in caps:
+        data['aggregate_id'] = caps['aggregate_id']
+
+    data['driver_version'] = caps['driver_version']
+    return data
+
+
+def get_cinder_pools(client):
+    """Fetch the pool stats from the current shard.
+
+    Pass in a pool name if you only want the stats for 1 pool
+
+    if raw is True, return the raw data from the scheduler.
+    """
+    volume_api = client.volume
+    return volume_api.backend_pools()
+
+
+@cached(TTLCache(ttl=3600, maxsize=1024))
+def get_volume_types(client):
+    """Get the list of volume types."""
+    volume_api = client.volume
+    return volume_api.types()
+
+
+def get_volume_types_by_name(client):
+    """Get the list of volume types by name."""
+    v_types = get_volume_types(client)
+    return {vt['name']: vt for vt in v_types}
+
+
+def get_scheduler_hints_from_volume(volume):
+    filter_properties = {}
+    if "scheduler_hint_same_host" in volume.metadata:
+        hint = volume.metadata["scheduler_hint_same_host"]
+        filter_properties["same_host"] = hint.split(',')
+
+    if "scheduler_hint_different_host" in volume.metadata:
+        hint = volume.metadata["scheduler_hint_different_host"]
+        filter_properties["different_host"] = hint.split(',')
+    return filter_properties
+
+
+def extract_shard_from_host(host):
+    """Extract the shard name from a cinder backend host entry."""
+    return host[host.find('vc-'):]
+
+
+def filter_pools(client, pools):
+    """Run the capabilities filter on the pools.
+    
+    This is used to assign pools to a volume type.
+
+    This uses the same capabilities filter as the cinder scheduler
+    to ensure the matching for volume types to pools is exactly the
+    same.
+    """
+    v_types = get_volume_types(client)
+    volume_types = []
+    for v_type in v_types:
+        volume_types.append(v_type)
+
+    scheduler_filter = filters.CinderSchedulerFilter()
+    scheduler_filter.add_filter(capabilities.CapabilitiesFilter())
+
+    pool_list = {'Unknown': []}
+
+    # now for each volume type we have filter the pool through it
+    # to see if it matches, not unlike the cinder scheduler.
+    for pool in pools:
+        found = False
+        for v_type in volume_types:
+            if scheduler_filter.run_filters(pool, v_type):
+                if v_type['name'] not in pool_list:
+                    pool_list[v_type['name']] = []
+                pool_list[v_type['name']].append(pool)
+                found = True
+        if not found:
+            pool_list['Unknown'].append(pool)
+
+    return pool_list
+
+
+def aggregate_pools(pools):
+    """Create aggregated stats for pools.
+
+    Some pools are reported by multiple drivers (shards). This will
+    aggregate the stats for those pools.
+
+    If a pool has an aggregate_id, it is an aggregate pool, meaning
+    that the same pool is reported by multiple drivers (shards).
+
+    """
+    def calc_virtual_free(available_capacity, allocated_capacity):
+        return available_capacity - allocated_capacity
+
+    def calc_free_percent(virtual_free, total_available_capacity):
+        if total_available_capacity == 0:
+            return 0
+        return math.floor((virtual_free / total_available_capacity) * 100)
+    
+    def calc_available_capacity(total_capacity, reserved_percentage):
+        reserved = float(reserved_percentage) / 100
+        reserved_capacity = math.floor(total_capacity * reserved)
+        return total_capacity - reserved_capacity
+
+    agg_pools = {}
+    for shard in pools:
+        for pool in pools[shard]:
+            if  "aggregate_id" in pool['capabilities']:
+                caps = pool['capabilities']
+                pool_name = extract_host(pool['name'], 'pool')
+                available_cap = calc_available_capacity(
+                    caps['total_capacity_gb'],
+                    caps['reserved_percentage']
+                )
+
+                if pool_name not in agg_pools:
+                    virtual_free = calc_virtual_free(
+                        available_cap,
+                        caps['allocated_capacity_gb']
+                    )
+                    agg_pools[pool_name] = {
+                        'name': pool_name,
+                        'aggregate_id': caps['aggregate_id'],
+                        'allocated_capacity_gb': caps['allocated_capacity_gb'],
+                        'free_capacity_gb': caps['free_capacity_gb'],
+                        'total_capacity_gb': caps['total_capacity_gb'],
+                        'reserved_percentage': caps['reserved_percentage'],
+                        'max_over_subscription_ratio': caps['max_over_subscription_ratio'],
+                        'thin_provisioning_support': caps['thin_provisioning_support'],
+                        'aggregate_id': caps['aggregate_id'],
+                        'virtual_free_capacity_gb': virtual_free,
+                    }
+                    if 'netapp_fqdn' in caps['custom_attributes']:
+                        agg_pools[pool_name]['netapp_fqdn'] = caps['custom_attributes']['netapp_fqdn']
+                    else:
+                        agg_pools[pool_name]['netapp_fqdn'] = "N/A"
+
+                    agg_pools[pool_name]['free_percent'] = calc_free_percent(
+                        virtual_free, available_cap
+                    )
+
+    return agg_pools
+

--- a/openstack_exporter/utils/filters/__init__.py
+++ b/openstack_exporter/utils/filters/__init__.py
@@ -1,0 +1,32 @@
+
+from typing import Callable, Protocol, runtime_checkable
+
+
+
+@runtime_checkable
+class CinderSchedulerBaseFilter(Protocol):
+    """Protocol API for a packet filter class.
+    """
+    def backend_passes(self, context, backend, volume_type):
+        """The Protocol for the backend filter."""
+        ...
+
+
+class CinderSchedulerFilter:
+
+    def __init__(self):
+        self.filters = []
+
+    def add_filter(self, filter: Callable):
+        if not isinstance(filter, CinderSchedulerBaseFilter):
+            raise ValueError("Filter must be a CinderSchedulerBaseFilter")
+        self.filters.append(filter)
+
+    def run_filters(self, pool, volume_type):
+        """Filter the pool against the volume type."""
+        filter_properties = {'resource_type': volume_type}
+
+        for filter in self.filters:
+            if not filter.backend_passes(pool, filter_properties):
+                return False
+        return True

--- a/openstack_exporter/utils/filters/capabilities.py
+++ b/openstack_exporter/utils/filters/capabilities.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2011 OpenStack Foundation.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from openstack_exporter.utils.filters import extra_specs_ops
+from openstack_exporter.utils.filters import CinderSchedulerBaseFilter
+
+
+class CapabilitiesFilter(CinderSchedulerBaseFilter):
+    """BackendFilter to work with resource (instance & volume) type records."""
+    
+    def _satisfies_extra_specs(self, capabilities, filter_properties):
+        """Check if capabilities satisfy resource type requirements.
+
+        Check that the capabilities provided by the services satisfy
+        the extra specs associated with the resource type.
+        """
+
+        # req_spec = filter_properties.get('request_spec')
+        # if req_spec and req_spec.get('operation') == 'extend_volume':
+        #     # NOTE(erlon): By default, cinder considers that every backend
+        #     # supports volume online extending. Those backends that don't
+        #     # support it should report online_extend_support=False.
+        #     online_extends = capabilities.get('online_extend_support', True)
+        #     if online_extends is False:
+        #         vol_prop = req_spec.get('volume_properties')
+        #         attach_status = vol_prop.get('attach_status')
+        #         if attach_status != VolumeAttachStatus.DETACHED:
+        #             self.console.print("Backend doesn't support attached volume extend")
+        #             return False
+
+        resource_type = filter_properties.get('resource_type')
+        if not resource_type:
+            return True
+
+        extra_specs = resource_type.get('extra_specs', [])
+        if not extra_specs:
+            return True
+
+        for key, req in extra_specs.items():
+
+            # Either not scoped format, or in capabilities scope
+            scope = key.split(':')
+
+            # Ignore scoped (such as vendor-specific) capabilities
+            if len(scope) > 1 and scope[0] != "capabilities":
+                continue
+            # Strip off prefix if spec started with 'capabilities:'
+            elif scope[0] == "capabilities":
+                del scope[0]
+
+            cap = capabilities
+            for index in range(len(scope)):
+                try:
+                    cap = cap[scope[index]]
+                except (TypeError, KeyError):
+                    #self.console.print("Backend doesn't provide capability '%(cap)s' ", {'cap': scope[index]})
+                    return False
+
+            # Make all capability values a list so we can handle lists
+            cap_list = [cap] if not isinstance(cap, list) else cap
+
+            # Loop through capability values looking for any match
+            for cap_value in cap_list:
+                if extra_specs_ops.match(cap_value, req):
+                    break
+            else:
+                # Nothing matched, so bail out
+                # self.console.print(
+                #     'Volume type extra spec requirement '
+                #     f'"{key}={req}" does not match reported '
+                #     f'capability "{cap}"')
+                return False
+        return True
+
+    def backend_passes(self, backend_state, filter_properties):
+        """Return a list of backends that can create resource_type."""
+        # Note(zhiteng) Currently only Cinder and Nova are using
+        # this filter, so the resource type is either instance or
+        # volume.
+        if not self._satisfies_extra_specs(backend_state.capabilities,
+                                           filter_properties):
+            # self.console.print(
+            #     f"{backend_state['name']} fails resource_type extra_specs requirements for "
+            #     f"volume_type '{filter_properties['resource_type']['name']}'"
+            # )
+            return False
+        return True

--- a/openstack_exporter/utils/filters/extra_specs_ops.py
+++ b/openstack_exporter/utils/filters/extra_specs_ops.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2011 OpenStack Foundation.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import operator
+
+from oslo_utils import strutils
+
+# 1. The following operations are supported:
+#   =, s==, s!=, s>=, s>, s<=, s<, <in>, <is>, <or>, ==, !=, >=, <=
+# 2. Note that <or> is handled in a different way below.
+# 3. If the first word in the extra_specs is not one of the operators,
+#   it is ignored.
+_op_methods = {'=': lambda x, y: float(x) >= float(y),
+               '<in>': lambda x, y: y in x,
+               '<is>': lambda x, y: (strutils.bool_from_string(x) is
+                                     strutils.bool_from_string(y)),
+               '==': lambda x, y: float(x) == float(y),
+               '!=': lambda x, y: float(x) != float(y),
+               '>=': lambda x, y: float(x) >= float(y),
+               '<=': lambda x, y: float(x) <= float(y),
+               's==': operator.eq,
+               's!=': operator.ne,
+               's<': operator.lt,
+               's<=': operator.le,
+               's>': operator.gt,
+               's>=': operator.ge}
+
+
+def match(value, req):
+    if req is None:
+        if value is None:
+            return True
+        else:
+            return False
+    words = req.split()
+
+    op = method = None
+    if words:
+        op = words.pop(0)
+        method = _op_methods.get(op)
+
+    if op != '<or>' and not method:
+        return value == req
+
+    if value is None:
+        return False
+
+    if op == '<or>':  # Ex: <or> v1 <or> v2 <or> v3
+        while True:
+            if words.pop(0) == value:
+                return True
+            if not words:
+                break
+            op = words.pop(0)  # remove a keyword <or>
+            if not words:
+                break
+        return False
+
+    try:
+        if words and method(value, words[0]):
+            return True
+    except ValueError:
+        pass
+
+    return False


### PR DESCRIPTION
This updates the way we calculate stats the same way the cinder scheduler does after associating the pool with a volume type.  Also collects the aggregated stats for the fcd based pools.  Also reporting the aggregate_id when available on a pool.