### PR TITLE
Support loading secrets from different config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Now run the exporter passing in the config.yaml
 openstack_exporter --config <path to openstack-config.yaml>
 ```
 
+In case you want your secrets stored somewhere else, e.g. when they come from a k8s Secret, you can provide them with the extra `--secrets` option
+```
+openstack_exporter --config <path to openstack-config.yaml> --secrets <path to openstack-secrets.yaml>
+```
 
 You can use the given Dockerfile to build and use the docker container for an easy rampup
 

--- a/openstack-config-sample.yaml
+++ b/openstack-config-sample.yaml
@@ -3,8 +3,10 @@ exporter:
   prometheus_port: 9102
 openstack:
   auth_url: https://identity-3.qa-de-1.cloud.sap/v3
-  username: <username here>
-  password: <password here>
+  # depending on your environment, you can set username/password here instead
+  # of supplying an extra file via --secrets
+  # username: <username here>
+  # password: <password here>
   user_domain_name: Default
   project_domain_name: ccadmin
   project_name: cloud_admin

--- a/openstack_exporter/exporter.py
+++ b/openstack_exporter/exporter.py
@@ -88,9 +88,11 @@ def get_config(config_file):
               help="specify exporter serving port")
 @click.option("-c", "--config", metavar="<config>",
               help="path to rest config")
+@click.option("--secrets", metavar="<secrets>",
+              help="path to YAML containing openstack password and optional username")
 @click.version_option()
 @click.help_option()
-def main(port, config):
+def main(port, config, secrets):
     if not config:
         raise click.ClickException("Missing OpenStack config yaml --config")
 
@@ -98,6 +100,14 @@ def main(port, config):
     exporter_config = config_obj['exporter']
     os_config = config_obj['openstack']
     collector_config = config_obj['collectors']
+
+    if secrets:
+        secrets_obj = get_config(secrets)
+        os_config.update(secrets_obj['openstack'])
+
+    if 'username' not in os_config or 'password' not in os_config:
+        raise click.ClickException("OpenStack username and/or password are unset. "
+                                   "Please provide them via --secrets config file")
 
     if exporter_config['log_level']:
         LOG.setLevel(logging.getLevelName(


### PR DESCRIPTION
Deploying the openstack-exporter via k8s, we want to split up config and secrets into ConfigMap and Secret k8s objects. To achieve this, we have to support loading username and password from another file. Therefore, we add a new option `--secrets` that requires a YAML file path. An example of such a YAML file is included in this commit.