### PR TITLE
[Cinder] Allow only expected backends

### DIFF
--- a/openstack_exporter/collectors/cinderbackend.py
+++ b/openstack_exporter/collectors/cinderbackend.py
@@ -398,17 +398,26 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
                 else:
                     LOG.debug(f"Got stats for {self.region} {backend}/{pool_name}")
 
-                yield from self._report_stats(
-                    shard_name, backend, data, caps, quota_obj)
+                # Are we allowed to report this backend?
+                report = False
                 if backend in seen_backends[shard_name]:
                     seen_backends[shard_name][backend] += 1
+                    report = True
                 elif self.allow_unexpected_backends:
                     LOG.debug(f"Adding unexpected backend {backend} "
                             f"to shard {shard_name}")
                     seen_backends[shard_name][backend] = 1
+                    report = True
                 else:
                     LOG.warning(f"Backend {backend} is not in expected "
                                 f"backends {self.expected_sharding_backends}")
+
+                if report:
+                    yield from self._report_stats(
+                        shard_name, backend, data, caps, quota_obj)
+                else:
+                    LOG.warning(f"Not reporting stats for {self.region} "
+                     f"{shard_name}/{backend}/{pool_name}")
 
         LOG.debug(f"seen backends {seen_backends}")
         for shard in seen_backends:


### PR DESCRIPTION
This patch updates the cinderbackend exporter to honor the custom config settings for expected_backends combined with the allow_unexpected_backends.

This will allow us to only export stats for enabled backends in regions.  Such as we have regions that have vmware_fcd enabled and other regions that don't have it enabled.  When we don't have a backend enabled, the exporter reports that the backend is down, which turns into a critical alert.

We are also in the process of disabling vmware backends in the regions where we have enabled vmware_fcd and migrated everything off of vmware to vmware_fcd.