### PR TITLE
Fix CVE-2026-26007: Upgrade cryptography to >=46.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests
 pyyaml
 master_password
 openstacksdk
-cryptography<43.0.0
+cryptography>=46.0.5
 python-cinderclient
 python-manilaclient
 cachetools


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert #1 (GHSA-r6ph-v2qm-q3c2)
- Upgrades `cryptography` from `<43.0.0` to `>=46.0.5`

## Vulnerability Details
The cryptography package <= 46.0.4 is vulnerable to a subgroup attack due to missing subgroup validation for SECT curves. This can lead to:
- Information leakage about private keys in ECDH
- Signature forgery in ECDSA when using SECT curves

**Severity:** High (CVSS 4.0: 8.2)

## References
- https://github.com/sapcc/openstack-exporter/security/dependabot/1
- https://github.com/pyca/cryptography/security/advisories/GHSA-r6ph-v2qm-q3c2
- https://nvd.nist.gov/vuln/detail/CVE-2026-26007