### PR TITLE
Fix CI: Update Alpine base image to 3.20 for cryptography 46.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
-FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine:3.12
+FROM keppel.eu-de-1.cloud.sap/ccloud-dockerhub-mirror/library/alpine:3.20
 
 LABEL source_repository="https://github.com/sapcc/openstack-exporter"
-RUN apk --update add python3 openssl ca-certificates bash python3-dev  git py3-pip && \
+RUN apk --update add python3 openssl ca-certificates bash python3-dev git py3-pip && \
     apk --update add --virtual build-dependencies libffi-dev openssl-dev libxml2 \
     libxml2-dev libxslt libxslt-dev build-base rust cargo
 RUN git config --global http.sslVerify false
-RUN git clone https://github.com/sapcc/openstack-exporter.git
-RUN pip3 install --upgrade pip
-RUN pip3 install setuptools_rust
 
-ADD . openstack-exporter/
-RUN cd openstack-exporter && pip3 install .
+ADD . /app/openstack-exporter/
+WORKDIR /app/openstack-exporter
 
-WORKDIR openstack-exporter
+RUN python3 -m venv /app/venv
+RUN /app/venv/bin/pip install --upgrade pip setuptools_rust
+RUN /app/venv/bin/pip install .
+
+COPY run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+# Create symlink for backwards compatibility with helm chart
+RUN ln -s /app/run.sh /usr/bin/openstack_exporter
+
+ENTRYPOINT ["/app/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Activate virtual environment and run the OpenStack exporter
+
+source /app/venv/bin/activate
+exec openstack_exporter "$@"


### PR DESCRIPTION
## Problem

CI build failing because Alpine 3.12's Rust toolchain cannot build `cryptography>=46.0.5` from source:

```
error: failed to parse manifest at `.../Cargo.toml`
Caused by: invalid type: map, expected a sequence for key `package.authors`
```

## Solution

- Update base image from Alpine 3.12 to Alpine 3.20
- Alpine 3.20 has Python 3.12 and a modern Rust toolchain that can build cryptography 46.x
- Use Python virtual environment at `/app/venv` instead of system-wide pip install
- Add `run.sh` script to activate venv before running the exporter
- Create symlink `/usr/bin/openstack_exporter -> /app/run.sh` for backwards compatibility with existing helm chart

## Backwards Compatibility

The helm chart uses `command: ["/usr/bin/openstack_exporter"]` - the symlink ensures this continues to work without any helm chart changes.

## Testing

This should fix the CI build failure reported in build #27.