### PR TITLE
Fix KeyError: 'custom_attributes' in aggregate_pools()

### DIFF
--- a/openstack_exporter/utils/cinder.py
+++ b/openstack_exporter/utils/cinder.py
@@ -346,8 +346,9 @@ def aggregate_pools(pools):
                         'aggregate_id': caps['aggregate_id'],
                         'virtual_free_capacity_gb': virtual_free,
                     }
-                    if 'netapp_fqdn' in caps['custom_attributes']:
-                        agg_pools[pool_name]['netapp_fqdn'] = caps['custom_attributes']['netapp_fqdn']
+                    custom_attrs = caps.get('custom_attributes', {})
+                    if 'netapp_fqdn' in custom_attrs:
+                        agg_pools[pool_name]['netapp_fqdn'] = custom_attrs['netapp_fqdn']
                     else:
                         agg_pools[pool_name]['netapp_fqdn'] = "N/A"
 


### PR DESCRIPTION
## Problem

`CinderBackendCollector` in qa-de-1 is crashing with:

```
KeyError: 'custom_attributes'
```

The `aggregate_pools()` function in `utils/cinder.py` uses direct dict access `caps['custom_attributes']` which throws when a backend doesn't include this field in its pool capabilities.

**Impact:** All cached Cinder metrics are cleared after the error. No Cinder backend metrics are being exported. Retries every 120s but fail repeatedly.

## Fix

Use `.get('custom_attributes', {})` so backends missing the field gracefully default `netapp_fqdn` to `"N/A"` instead of crashing the entire collector.

## Testing

- Backends WITH `custom_attributes` behave exactly as before
- Backends WITHOUT `custom_attributes` now get `netapp_fqdn = "N/A"` instead of crashing