### PR TITLE
Fix TypeError: 'NoneType' is not iterable in _report_stats()

### DIFF
--- a/openstack_exporter/collectors/cinderbackend.py
+++ b/openstack_exporter/collectors/cinderbackend.py
@@ -182,7 +182,7 @@ class CinderBackendCollector(BaseCollector.BaseCollector):
             {'pool_state': caps.get('pool_state', 'down')},
             shard_name, backend, pool_name, az
         )
-        down_reason = caps.get('pool_down_reason', 'unknown')
+        down_reason = caps.get('pool_down_reason') or 'unknown'
         if caps.get('backend_state', 'down') == 'down':
             down_reason = 'backend_down'
         elif 'Datastore marked as draining' in down_reason:


### PR DESCRIPTION
## Problem

`CinderBackendCollector` in qa-de-1 is crashing with:

```
TypeError: argument of type 'NoneType' is not iterable
```

At `cinderbackend.py:188`:
```python
elif 'Datastore marked as draining' in down_reason:
```

**Root cause:** A backend returns `pool_down_reason: null` (explicit None) in its capabilities. `caps.get('pool_down_reason', 'unknown')` returns `None` because the key *exists* — the default only applies when the key is missing. Then `'...' in None` throws TypeError.

**Impact:** Same as #31 — all cached Cinder metrics cleared, no metrics exported, retries failing every 120s.

## Fix

```python
# Before — default only works if key is absent
down_reason = caps.get('pool_down_reason', 'unknown')

# After — handles both missing key AND explicit None
down_reason = caps.get('pool_down_reason') or 'unknown'
```

## Testing

- Backend with `pool_down_reason: 'some reason'` → works as before
- Backend with `pool_down_reason: null` → now defaults to `'unknown'`
- Backend without `pool_down_reason` key → now defaults to `'unknown'`